### PR TITLE
Regenerated controller with code-gen `v0.43.2-7-g3722729`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,11 +1,11 @@
 ack_generate_info:
-  build_date: "2025-02-20T18:04:23Z"
-  build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
-  go_version: go1.24.0
-  version: v0.43.2
+  build_date: "2025-03-26T22:39:45Z"
+  build_hash: 3722729cebe6d3c03c7e442655ef0846f91566a2
+  go_version: go1.24.1
+  version: v0.43.2-7-g3722729
 api_directory_checksum: 2b29d9314a6ca77238f1a5fe09772f307485d94f
 api_version: v1alpha1
-aws_sdk_go_version: 1.32.6
+aws_sdk_go_version: v1.32.6
 generator_config_info:
   file_checksum: d2f4a656f9dccd7026fa8ab2be568da2b62379f6
   original_file_name: generator.yaml

--- a/pkg/resource/integration/sdk.go
+++ b/pkg/resource/integration/sdk.go
@@ -397,7 +397,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.TimeoutInMillis != nil {
 		timeoutInMillisCopy0 := *r.ko.Spec.TimeoutInMillis
 		if timeoutInMillisCopy0 > math.MaxInt32 || timeoutInMillisCopy0 < math.MinInt32 {
-			return nil, fmt.Errorf("error: field TimeoutInMillis is of type int32")
+			return nil, fmt.Errorf("error: field timeoutInMillis is of type int32")
 		}
 		timeoutInMillisCopy := int32(timeoutInMillisCopy0)
 		res.TimeoutInMillis = &timeoutInMillisCopy

--- a/pkg/resource/rest_api/delta.go
+++ b/pkg/resource/rest_api/delta.go
@@ -118,7 +118,9 @@ func newResourceDelta(
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Version, b.ko.Spec.Version) {

--- a/pkg/resource/rest_api/manager.go
+++ b/pkg/resource/rest_api/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags map[string]*string
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/rest_api/tags.go
+++ b/pkg/resource/rest_api/tags.go
@@ -30,15 +30,17 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags map[string]*string) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags map[string]*string) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for k, v := range tags {
 		if v == nil {
 			result[k] = ""
@@ -47,18 +49,21 @@ func ToACKTags(tags map[string]*string) acktags.Tags {
 		}
 	}
 
-	return result
+	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into map[string]*string shape.
+// fromACKTags converts the tags parameter into map[string]*string shape.
 // This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) map[string]*string {
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTags(tags acktags.Tags, keyOrder []string) map[string]*string {
 	result := map[string]*string{}
+
+	_ = keyOrder
 	for k, v := range tags {
-		vCopy := v
-		result[k] = &vCopy
+		result[k] = &v
 	}
+
 	return result
 }
 

--- a/pkg/resource/stage/delta.go
+++ b/pkg/resource/stage/delta.go
@@ -128,7 +128,9 @@ func newResourceDelta(
 			delta.Add("Spec.StageName", a.ko.Spec.StageName, b.ko.Spec.StageName)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TracingEnabled, b.ko.Spec.TracingEnabled) {

--- a/pkg/resource/stage/manager.go
+++ b/pkg/resource/stage/manager.go
@@ -299,9 +299,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags map[string]*string
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/stage/tags.go
+++ b/pkg/resource/stage/tags.go
@@ -30,15 +30,17 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags map[string]*string) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags map[string]*string) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for k, v := range tags {
 		if v == nil {
 			result[k] = ""
@@ -47,18 +49,21 @@ func ToACKTags(tags map[string]*string) acktags.Tags {
 		}
 	}
 
-	return result
+	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into map[string]*string shape.
+// fromACKTags converts the tags parameter into map[string]*string shape.
 // This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) map[string]*string {
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTags(tags acktags.Tags, keyOrder []string) map[string]*string {
 	result := map[string]*string{}
+
+	_ = keyOrder
 	for k, v := range tags {
-		vCopy := v
-		result[k] = &vCopy
+		result[k] = &v
 	}
+
 	return result
 }
 

--- a/pkg/resource/vpc_link/delta.go
+++ b/pkg/resource/vpc_link/delta.go
@@ -57,7 +57,9 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if len(a.ko.Spec.TargetARNs) != len(b.ko.Spec.TargetARNs) {

--- a/pkg/resource/vpc_link/manager.go
+++ b/pkg/resource/vpc_link/manager.go
@@ -299,9 +299,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags map[string]*string
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags map[string]*string
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_link/tags.go
+++ b/pkg/resource/vpc_link/tags.go
@@ -30,15 +30,17 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags map[string]*string) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags map[string]*string) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for k, v := range tags {
 		if v == nil {
 			result[k] = ""
@@ -47,18 +49,21 @@ func ToACKTags(tags map[string]*string) acktags.Tags {
 		}
 	}
 
-	return result
+	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into map[string]*string shape.
+// fromACKTags converts the tags parameter into map[string]*string shape.
 // This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) map[string]*string {
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTags(tags acktags.Tags, keyOrder []string) map[string]*string {
 	result := map[string]*string{}
+
+	_ = keyOrder
 	for k, v := range tags {
-		vCopy := v
-		result[k] = &vCopy
+		result[k] = &v
 	}
+
 	return result
 }
 


### PR DESCRIPTION
Description of changes:
Regenerated controller with updated code-gen


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
