### PR TITLE
Generate with code-generator v0.47.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2025-05-13T04:51:10Z"
-  build_hash: 55bf57b2806c33a7fcd074be403f26ce3f8e58db
+  build_date: "2025-05-28T16:46:26Z"
+  build_hash: 66a58d259146834e61b211a9a01609beaa58ef77
   go_version: go1.24.2
-  version: v0.46.2
-api_directory_checksum: 94b9a1c92c36be454d70625764b603b5c2d5b554
+  version: v0.47.1
+api_directory_checksum: d82f4d79382f6fe41728ddbdfb5ec025b658575f
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:

--- a/apis/v1alpha1/api_integration_response.go
+++ b/apis/v1alpha1/api_integration_response.go
@@ -58,6 +58,8 @@ type APIIntegrationResponseSpec struct {
 	SelectionPattern *string `json:"selectionPattern,omitempty"`
 	// Specifies the status code that is used to map the integration response to
 	// an existing MethodResponse.
+	//
+	// Regex Pattern: `^[1-5]\d\d$`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	StatusCode *string `json:"statusCode"`

--- a/apis/v1alpha1/api_method_response.go
+++ b/apis/v1alpha1/api_method_response.go
@@ -52,6 +52,8 @@ type APIMethodResponseSpec struct {
 	RestAPIID  *string                                  `json:"restAPIID,omitempty"`
 	RestAPIRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"restAPIRef,omitempty"`
 	// The method response's status code.
+	//
+	// Regex Pattern: `^[1-5]\d\d$`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	StatusCode *string `json:"statusCode"`

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/apigateway-controller
-  newTag: 1.2.2
+  newTag: 1.2.3

--- a/config/crd/bases/apigateway.services.k8s.aws_apiintegrationresponses.yaml
+++ b/config/crd/bases/apigateway.services.k8s.aws_apiintegrationresponses.yaml
@@ -129,6 +129,8 @@ spec:
                 description: |-
                   Specifies the status code that is used to map the integration response to
                   an existing MethodResponse.
+
+                  Regex Pattern: `^[1-5]\d\d$`
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable once set

--- a/config/crd/bases/apigateway.services.k8s.aws_apimethodresponses.yaml
+++ b/config/crd/bases/apigateway.services.k8s.aws_apimethodresponses.yaml
@@ -116,7 +116,10 @@ spec:
                     type: object
                 type: object
               statusCode:
-                description: The method response's status code.
+                description: |-
+                  The method response's status code.
+
+                  Regex Pattern: `^[1-5]\d\d$`
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable once set

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/aws-controllers-k8s/ec2-controller v1.2.15
-	github.com/aws-controllers-k8s/runtime v0.46.1
+	github.com/aws-controllers-k8s/runtime v0.47.0
 	github.com/aws/aws-sdk-go v1.55.0
 	github.com/aws/aws-sdk-go-v2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.28.10

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aws-controllers-k8s/ec2-controller v1.2.15 h1:Cij1ho3w0NxCJZOLG3ggUp8DnP/fvj43f0DSIRnySpM=
 github.com/aws-controllers-k8s/ec2-controller v1.2.15/go.mod h1:G27V4zTX8qoNQBm5TlEn1IxJSzB8XdFEYJiXPVgjcvE=
-github.com/aws-controllers-k8s/runtime v0.46.1 h1:61RU6uYiFSp0cDhv52vAmaPzrebzoudtsp1fGkk6iLk=
-github.com/aws-controllers-k8s/runtime v0.46.1/go.mod h1:G2UMBKA7qgXG4JV16NTIUp715uqvUEvWaa7TG1I527U=
+github.com/aws-controllers-k8s/runtime v0.47.0 h1:pWzMLrwAFrAmMuSukYDLrQp5Yw594w1ke6XWGmI3uyo=
+github.com/aws-controllers-k8s/runtime v0.47.0/go.mod h1:G2UMBKA7qgXG4JV16NTIUp715uqvUEvWaa7TG1I527U=
 github.com/aws/aws-sdk-go v1.55.0 h1:hVALKPjXz33kP1R9nTyJpUK7qF59dO2mleQxUW9mCVE=
 github.com/aws/aws-sdk-go v1.55.0/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apigateway-chart
 description: A Helm chart for the ACK service controller for Amazon API Gateway (apigateway)
-version: 1.2.2
-appVersion: 1.2.2
+version: 1.2.3
+appVersion: 1.2.3
 home: https://github.com/aws-controllers-k8s/apigateway-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/crds/apigateway.services.k8s.aws_apiintegrationresponses.yaml
+++ b/helm/crds/apigateway.services.k8s.aws_apiintegrationresponses.yaml
@@ -129,6 +129,8 @@ spec:
                 description: |-
                   Specifies the status code that is used to map the integration response to
                   an existing MethodResponse.
+
+                  Regex Pattern: `^[1-5]\d\d$`
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable once set

--- a/helm/crds/apigateway.services.k8s.aws_apimethodresponses.yaml
+++ b/helm/crds/apigateway.services.k8s.aws_apimethodresponses.yaml
@@ -116,7 +116,10 @@ spec:
                     type: object
                 type: object
               statusCode:
-                description: The method response's status code.
+                description: |-
+                  The method response's status code.
+
+                  Regex Pattern: `^[1-5]\d\d$`
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable once set

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/apigateway-controller:1.2.2".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/apigateway-controller:1.2.3".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/apigateway-controller
-  tag: 1.2.2
+  tag: 1.2.3
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:
- Run code-generator v0.47.1
- Update runtime to v0.47.0
- Update patch version to 1.2.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
