### PR TITLE
tests: Ready condition rename for apigateway-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aws-controllers-k8s/ec2-controller v1.2.15 h1:Cij1ho3w0NxCJZOLG3ggUp8DnP/fvj43f0DSIRnySpM=
 github.com/aws-controllers-k8s/ec2-controller v1.2.15/go.mod h1:G27V4zTX8qoNQBm5TlEn1IxJSzB8XdFEYJiXPVgjcvE=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.55.0 h1:hVALKPjXz33kP1R9nTyJpUK7qF59dO2mleQxUW9mCVE=
 github.com/aws/aws-sdk-go v1.55.0/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
@@ -86,6 +84,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.54.0 h1:Mxf2oUm5Skgf0sLik5otKE5+I2+0ziC1aRWZJOwRiWQ=
+github.com/gustavodiaz7722/ack-runtime v0.54.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@55a6fdba4a637f0702cf164035f03c16c8d6b884
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@77f6bc5602557fe48e0dd157fefbd97a6aa3e54b

--- a/test/e2e/tests/deployment_test.py
+++ b/test/e2e/tests/deployment_test.py
@@ -73,7 +73,7 @@ def simple_deployment(apigateway_client, simple_integration):
     }
     k8s.wait_on_condition(
         ref,
-        condition.CONDITION_TYPE_RESOURCE_SYNCED,
+        condition.CONDITION_TYPE_READY,
         "True",
         wait_periods=60,
     )

--- a/test/e2e/tests/resource_test.py
+++ b/test/e2e/tests/resource_test.py
@@ -73,7 +73,7 @@ def simple_resource(simple_rest_api, apigateway_client) -> Tuple[k8s.CustomResou
     }
     k8s.wait_on_condition(
         ref,
-        condition.CONDITION_TYPE_RESOURCE_SYNCED,
+        condition.CONDITION_TYPE_READY,
         "True",
         wait_periods=60,
     )

--- a/test/e2e/tests/rest_api_test.py
+++ b/test/e2e/tests/rest_api_test.py
@@ -75,7 +75,7 @@ def simple_rest_api(apigateway_client) -> Tuple[k8s.CustomResourceReference, Dic
     assert k8s.get_resource_exists(ref)
     k8s.wait_on_condition(
         ref,
-        condition.CONDITION_TYPE_RESOURCE_SYNCED,
+        condition.CONDITION_TYPE_READY,
         "True",
         wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
     )
@@ -132,7 +132,7 @@ class TestRestAPI:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
         assert k8s.wait_on_condition(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             "True",
             wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
         )

--- a/test/e2e/tests/stage_test.py
+++ b/test/e2e/tests/stage_test.py
@@ -116,7 +116,7 @@ class TestStage:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
         assert k8s.wait_on_condition(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             'True',
             wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
         )

--- a/test/e2e/tests/vpc_link_test.py
+++ b/test/e2e/tests/vpc_link_test.py
@@ -81,7 +81,7 @@ class TestVPCLink:
 
         assert k8s.wait_on_condition(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             'True',
             wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
         )


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.